### PR TITLE
prevent bdii class being included when using {top,sam,site}bdii classes

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -5,6 +5,7 @@ class bdii {
          class {'bdii::install':}
          class {'bdii::service':}
          class {'bdii::firewall':}
+         class {'bdii::config' :}
     }
    default: {
               # There is some fedora configuration present but I can't actually get it to work.

--- a/manifests/sambdii.pp
+++ b/manifests/sambdii.pp
@@ -2,6 +2,11 @@ class bdii::sambdii inherits bdii::params {
 
   Class[Bdii::Config] -> Class[Bdii::Sambdii]
 
+  if defined( Class["bdii"]) {
+    fail("Do not include / declare top level bdii class when using bdii::sitebdii")
+  }
+  include bdii::install
+  include bdii::firewall
   class {"bdii::config":
     delete_delay => $bdii::params::sitedeletedelay,
   } 

--- a/manifests/sitebdii.pp
+++ b/manifests/sitebdii.pp
@@ -24,6 +24,11 @@ class bdii::sitebdii(
 
   Class[Bdii::Config] -> Class[Bdii::Sitebdii]
 
+  if defined( Class["bdii"]) {
+    fail("Do not include / declare top level bdii class when using bdii::sitebdii")
+  }
+  include bdii::install
+  include bdii::firewall
   class {"bdii::config":
     delete_delay => $bdii::params::sitedeletedelay,
   }

--- a/manifests/topbdii.pp
+++ b/manifests/topbdii.pp
@@ -2,6 +2,11 @@ class bdii::topbdii inherits bdii::params {
 
   Class[Bdii::Config] -> Class[Bdii::Topbdii]
 
+  if defined( Class["bdii"]) {
+    fail("Do not include / declare top level bdii class when using bdii::sitebdii")
+  }
+  include bdii::install
+  include bdii::firewall
   class{"bdii::config":
     delete_delay => $bdii::params::bdiideletedelay,
   }


### PR DESCRIPTION
Add config back to init.pp, throw fail in subclasses, and include config.

Not completely happy with this, but seems easier to force removal of "include bdii" or "class {'bdii' :}" from bdii servers than a new class for bdii resource.
