### PR TITLE
Allow the firewall component to not be loaded

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,11 +1,15 @@
-class bdii {
+class bdii (
+  $manage_firewall = true,
+) {
 
   case $::operatingsystem {
     'RedHat','SLC','SL','Scientific','CentOS':   {
       include bdii::install
       include bdii::service
-      include bdii::firewall
       include bdii::config
+      if ($manage_firewall) {
+        include bdii::firewall
+      }
   }
     default: {
               # There is some fedora configuration present but I can't actually get it to work.


### PR DESCRIPTION
DPM uses this module to configure the DPM services. Currently all of the DPM components do not configure the firewall, but the BDII module does. Adding a flag to allow the firewall component to not be loaded